### PR TITLE
eliminar propina duplicada en el corte

### DIFF
--- a/app/System/Corte/Corte.php
+++ b/app/System/Corte/Corte.php
@@ -216,7 +216,7 @@ trait Corte{
     public function diferencia($efectivo_inicial, $efectivo_ingresado, $inicio, $fin, $cajero){
         $total = $efectivo_inicial 
                 + $this->totalEfectivo($inicio, $fin, $cajero) 
-                + $this->propinaEfectivo($inicio, $fin, $cajero)
+               // + $this->propinaEfectivo($inicio, $fin, $cajero)
                 + $this->entradasEfectivo($inicio, $fin, $cajero)
                 - $this->salidasEfectivo($inicio, $fin, $cajero)
                 - $this->gastosEfectivo($inicio, $fin, $cajero)


### PR DESCRIPTION
La propina se comentó en el corte porque se estaba duplicando ya que la funcion total efectivo ya incluye el precio con propina; 